### PR TITLE
follows-belongs-to-usres

### DIFF
--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::FollowsController < ApplicationController
     def create
-        follow = Follow.new(user_id: params[:user_id], creator_id: params[:creator_id])
+        user = User.find_by(id: params[:user_id])
+        follow = user.follows.new(creator_id: params[:creator_id])
 
         if follow.save
             render json: { success: "Follow added successfully" }, status: :created

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,2 +1,4 @@
 class Follow < ApplicationRecord
+    belongs_to :user
+    validates :creator_id, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :creators, only: [:show, :index, :create, :update, :destroy]
-      resources :follows, only: [:create]
+      resources :users, only: [:create] do
+        resources :follows, only: [:create]
+      end
     end
   end
 end

--- a/log/test.log
+++ b/log/test.log
@@ -753,3 +753,3507 @@ Completed 200 OK in 17ms (Views: 0.2ms | ActiveRecord: 0.4ms | Allocations: 9772
   [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
   [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
   [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[35m (37.1ms)[0m  [1m[35mDROP DATABASE IF EXISTS "backend_test"[0m
+  [1m[35m (141.2ms)[0m  [1m[35mCREATE DATABASE "backend_test" ENCODING = 'unicode'[0m
+  [1m[35mSQL (0.7ms)[0m  [1m[35mCREATE EXTENSION IF NOT EXISTS "plpgsql"[0m
+  [1m[35m (0.1ms)[0m  [1m[35mDROP TABLE IF EXISTS "creators" CASCADE[0m
+  [1m[35m (35.4ms)[0m  [1m[35mCREATE TABLE "creators" ("id" bigserial primary key, "name" character varying, "youtube_handle" character varying, "twitch_handle" character varying, "twitter_handle" character varying, "created_at" timestamp(6) NOT NULL, "updated_at" timestamp(6) NOT NULL)[0m
+  [1m[35m (0.2ms)[0m  [1m[35mDROP TABLE IF EXISTS "follows" CASCADE[0m
+  [1m[35m (1.2ms)[0m  [1m[35mCREATE TABLE "follows" ("id" bigserial primary key, "user_id" bigint NOT NULL, "creator_id" bigint NOT NULL, "created_at" timestamp(6) NOT NULL, "updated_at" timestamp(6) NOT NULL)[0m
+  [1m[35m (2.1ms)[0m  [1m[35mCREATE INDEX "index_follows_on_creator_id" ON "follows" ("creator_id")[0m
+  [1m[35m (2.8ms)[0m  [1m[35mCREATE INDEX "index_follows_on_user_id" ON "follows" ("user_id")[0m
+  [1m[35m (0.1ms)[0m  [1m[35mDROP TABLE IF EXISTS "users" CASCADE[0m
+  [1m[35m (4.8ms)[0m  [1m[35mCREATE TABLE "users" ("id" bigserial primary key, "name" character varying, "email" character varying, "created_at" timestamp(6) NOT NULL, "updated_at" timestamp(6) NOT NULL)[0m
+  [1m[35m (3.4ms)[0m  [1m[35mALTER TABLE "follows" ADD CONSTRAINT "fk_rails_516a22fd7d"
+FOREIGN KEY ("creator_id")
+  REFERENCES "creators" ("id")
+[0m
+  [1m[35m (14.4ms)[0m  [1m[35mALTER TABLE "follows" ADD CONSTRAINT "fk_rails_32479bd030"
+FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id")
+[0m
+  [1m[35m (8.6ms)[0m  [1m[35mCREATE TABLE "schema_migrations" ("version" character varying NOT NULL PRIMARY KEY)[0m
+  [1m[36mActiveRecord::SchemaMigration Load (0.6ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+  [1m[35m (0.5ms)[0m  [1m[32mINSERT INTO "schema_migrations" (version) VALUES (20240321214443)[0m
+  [1m[35m (0.8ms)[0m  [1m[32mINSERT INTO "schema_migrations" (version) VALUES
+(20240321214328),
+(20240321214241);[0m
+  [1m[35m (1.6ms)[0m  [1m[35mCREATE TABLE "ar_internal_metadata" ("key" character varying NOT NULL PRIMARY KEY, "value" character varying, "created_at" timestamp(6) NOT NULL, "updated_at" timestamp(6) NOT NULL)[0m
+  [1m[36mActiveRecord::InternalMetadata Load (0.5ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "environment"]]
+  [1m[36mActiveRecord::InternalMetadata Create (0.3ms)[0m  [1m[32mINSERT INTO "ar_internal_metadata" ("key", "value", "created_at", "updated_at") VALUES ('environment', 'test', '2024-03-25 21:06:37.003509', '2024-03-25 21:06:37.003513') RETURNING "key"[0m
+  [1m[36mActiveRecord::InternalMetadata Load (0.1ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "environment"]]
+  [1m[36mActiveRecord::InternalMetadata Load (0.1ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::InternalMetadata Create (0.1ms)[0m  [1m[32mINSERT INTO "ar_internal_metadata" ("key", "value", "created_at", "updated_at") VALUES ('schema_sha1', 'c24a2f7224af620feec4859c7009386953375eb5', '2024-03-25 21:06:37.004782', '2024-03-25 21:06:37.004783') RETURNING "key"[0m
+  [1m[36mActiveRecord::SchemaMigration Load (0.4ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (12.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.7ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.112221"], ["updated_at", "2024-03-25 21:06:37.112221"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.114399"], ["updated_at", "2024-03-25 21:06:37.114399"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.115449"], ["updated_at", "2024-03-25 21:06:37.115449"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.116274"], ["updated_at", "2024-03-25 21:06:37.116274"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.147575"], ["updated_at", "2024-03-25 21:06:37.147575"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.6ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.148727"], ["updated_at", "2024-03-25 21:06:37.148727"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.149973"], ["updated_at", "2024-03-25 21:06:37.149973"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.150904"], ["updated_at", "2024-03-25 21:06:37.150904"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.164580"], ["updated_at", "2024-03-25 21:06:37.164580"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.4ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:06:37.165316"], ["id", 9]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.5ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.6ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.8ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:06:37.196705"], ["updated_at", "2024-03-25 21:06:37.196705"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.4ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:06:37.198543"], ["id", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (1.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010c618b60>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.229153"], ["updated_at", "2024-03-25 21:06:37.229153"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 10], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 21ms (Views: 0.1ms | ActiveRecord: 15.3ms | Allocations: 6428)
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010ce39600>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.250674"], ["updated_at", "2024-03-25 21:06:37.250674"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 11], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 1.1ms | Allocations: 1306)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.254661"], ["updated_at", "2024-03-25 21:06:37.254661"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/12" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"12", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 12], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (1.1ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 12]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 2ms (Views: 0.0ms | ActiveRecord: 1.4ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 12], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.259066"], ["updated_at", "2024-03-25 21:06:37.259066"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 13], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.262160"], ["updated_at", "2024-03-25 21:06:37.262160"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.263119"], ["updated_at", "2024-03-25 21:06:37.263119"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.264067"], ["updated_at", "2024-03-25 21:06:37.264067"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.264972"], ["updated_at", "2024-03-25 21:06:37.264972"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.2ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.267761"], ["updated_at", "2024-03-25 21:06:37.267761"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/18" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"18", "creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 18], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2042)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.274433"], ["updated_at", "2024-03-25 21:06:37.274433"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/19" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"19", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 19], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2181)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.282143"], ["updated_at", "2024-03-25 21:06:37.282143"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/20" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"20", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 20], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x000000010c8962c0>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"20", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.4ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 20], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.3ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:06:37.285641"], ["id", 20]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 2ms (Views: 0.1ms | ActiveRecord: 0.9ms | Allocations: 1007)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.289516"], ["updated_at", "2024-03-25 21:06:37.289516"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:06:37.293399"], ["updated_at", "2024-03-25 21:06:37.293399"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.294319"], ["updated_at", "2024-03-25 21:06:37.294319"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:06:37.295352"], ["updated_at", "2024-03-25 21:06:37.295352"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/follows" for 127.0.0.1 at 2024-03-25 15:06:37 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>2, "creator_id"=>23, "follow"=>{"user_id"=>2, "creator_id"=>23}}
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mFollow Create (1.6ms)[0m  [1m[32mINSERT INTO "follows" ("user_id", "creator_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["user_id", 2], ["creator_id", 23], ["created_at", "2024-03-25 21:06:37.301968"], ["updated_at", "2024-03-25 21:06:37.301968"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 6ms (Views: 0.0ms | ActiveRecord: 5.0ms | Allocations: 4476)
+  [1m[36mFollow Load (0.1ms)[0m  [1m[34mSELECT "follows".* FROM "follows" ORDER BY "follows"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (1.7ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (0.9ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.7ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (1.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.690174"], ["updated_at", "2024-03-25 21:07:05.690174"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.692340"], ["updated_at", "2024-03-25 21:07:05.692340"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.693259"], ["updated_at", "2024-03-25 21:07:05.693259"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.694192"], ["updated_at", "2024-03-25 21:07:05.694192"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.721893"], ["updated_at", "2024-03-25 21:07:05.721893"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.722763"], ["updated_at", "2024-03-25 21:07:05.722763"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.723578"], ["updated_at", "2024-03-25 21:07:05.723578"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.724402"], ["updated_at", "2024-03-25 21:07:05.724402"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.735358"], ["updated_at", "2024-03-25 21:07:05.735358"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (1.3ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:07:05.736060"], ["id", 32]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.6ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.4ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:07:05.747935"], ["updated_at", "2024-03-25 21:07:05.747935"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.3ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:07:05.748734"], ["id", 3]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (1.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010ce355a0>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.767855"], ["updated_at", "2024-03-25 21:07:05.767855"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 33], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 20ms (Views: 0.1ms | ActiveRecord: 14.8ms | Allocations: 6426)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010d870790>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.787533"], ["updated_at", "2024-03-25 21:07:05.787533"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 34], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 0.7ms | Allocations: 1306)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.790896"], ["updated_at", "2024-03-25 21:07:05.790896"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/35" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"35", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 35], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (1.2ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 35]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 2ms (Views: 0.1ms | ActiveRecord: 1.4ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 35], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.795287"], ["updated_at", "2024-03-25 21:07:05.795287"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 36], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (11.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.798433"], ["updated_at", "2024-03-25 21:07:05.798433"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.810578"], ["updated_at", "2024-03-25 21:07:05.810578"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.811541"], ["updated_at", "2024-03-25 21:07:05.811541"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.812439"], ["updated_at", "2024-03-25 21:07:05.812439"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.815290"], ["updated_at", "2024-03-25 21:07:05.815290"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/41" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"41", "creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 41], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.2ms | Allocations: 2017)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.822160"], ["updated_at", "2024-03-25 21:07:05.822160"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/42" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"42", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 42], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.830000"], ["updated_at", "2024-03-25 21:07:05.830000"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/43" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"43", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 43], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x000000010dbbfa18>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"43", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 43], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:07:05.833283"], ["id", 43]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 1ms (Views: 0.0ms | ActiveRecord: 0.7ms | Allocations: 1007)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.8ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.836452"], ["updated_at", "2024-03-25 21:07:05.836452"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.4ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:07:05.840986"], ["updated_at", "2024-03-25 21:07:05.840986"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.841866"], ["updated_at", "2024-03-25 21:07:05.841866"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:07:05.842684"], ["updated_at", "2024-03-25 21:07:05.842684"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/follows" for 127.0.0.1 at 2024-03-25 15:07:05 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>4, "creator_id"=>46, "follow"=>{"user_id"=>4, "creator_id"=>46}}
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mFollow Create (0.8ms)[0m  [1m[32mINSERT INTO "follows" ("user_id", "creator_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["user_id", 4], ["creator_id", 46], ["created_at", "2024-03-25 21:07:05.848623"], ["updated_at", "2024-03-25 21:07:05.848623"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 6ms (Views: 0.0ms | ActiveRecord: 3.6ms | Allocations: 4457)
+  [1m[36mFollow Load (0.1ms)[0m  [1m[34mSELECT "follows".* FROM "follows" ORDER BY "follows"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (2.4ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (1.1ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.8ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (1.5ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:37.922962"], ["updated_at", "2024-03-25 21:09:37.922962"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:37.925775"], ["updated_at", "2024-03-25 21:09:37.925775"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:37.926691"], ["updated_at", "2024-03-25 21:09:37.926691"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:37.927621"], ["updated_at", "2024-03-25 21:09:37.927621"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.4ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:37.956960"], ["updated_at", "2024-03-25 21:09:37.956960"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:37.957879"], ["updated_at", "2024-03-25 21:09:37.957879"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:37.958749"], ["updated_at", "2024-03-25 21:09:37.958749"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:37.959712"], ["updated_at", "2024-03-25 21:09:37.959712"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:37.971189"], ["updated_at", "2024-03-25 21:09:37.971189"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (1.3ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:09:37.971867"], ["id", 55]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.7ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.9ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:09:38.001653"], ["updated_at", "2024-03-25 21:09:38.001653"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.4ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:09:38.003976"], ["id", 5]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (1.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:09:38 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010b293c20>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.034364"], ["updated_at", "2024-03-25 21:09:38.034364"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 56], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 30ms (Views: 0.2ms | ActiveRecord: 24.4ms | Allocations: 6426)
+  [1m[36mCreator Count (0.5ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:09:38 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010bbbbe10>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.065068"], ["updated_at", "2024-03-25 21:09:38.065068"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 57], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 1.2ms | Allocations: 1306)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:09:38 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.069451"], ["updated_at", "2024-03-25 21:09:38.069451"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/58" for 127.0.0.1 at 2024-03-25 15:09:38 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"58", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 58], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (1.2ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 58]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 2ms (Views: 0.0ms | ActiveRecord: 1.5ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 58], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.074044"], ["updated_at", "2024-03-25 21:09:38.074044"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:09:38 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 59], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.077288"], ["updated_at", "2024-03-25 21:09:38.077288"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.078255"], ["updated_at", "2024-03-25 21:09:38.078255"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.079255"], ["updated_at", "2024-03-25 21:09:38.079255"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.080197"], ["updated_at", "2024-03-25 21:09:38.080197"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:09:38 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.2ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.082992"], ["updated_at", "2024-03-25 21:09:38.082992"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/64" for 127.0.0.1 at 2024-03-25 15:09:38 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"64", "creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 64], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.2ms | Allocations: 2042)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.089724"], ["updated_at", "2024-03-25 21:09:38.089724"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/65" for 127.0.0.1 at 2024-03-25 15:09:38 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"65", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 65], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.097453"], ["updated_at", "2024-03-25 21:09:38.097453"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/66" for 127.0.0.1 at 2024-03-25 15:09:38 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"66", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 66], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x000000010b512280>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"66", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 66], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:09:38.101138"], ["id", 66]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 2ms (Views: 0.1ms | ActiveRecord: 0.7ms | Allocations: 1007)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.104949"], ["updated_at", "2024-03-25 21:09:38.104949"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:09:38 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:09:38.108810"], ["updated_at", "2024-03-25 21:09:38.108810"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.109744"], ["updated_at", "2024-03-25 21:09:38.109744"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.7ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:09:38.110761"], ["updated_at", "2024-03-25 21:09:38.110761"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (1.4ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (0.9ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.6ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.4ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.027562"], ["updated_at", "2024-03-25 21:10:18.027562"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.029223"], ["updated_at", "2024-03-25 21:10:18.029223"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.030090"], ["updated_at", "2024-03-25 21:10:18.030090"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.030927"], ["updated_at", "2024-03-25 21:10:18.030927"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.058068"], ["updated_at", "2024-03-25 21:10:18.058068"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.058989"], ["updated_at", "2024-03-25 21:10:18.058989"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.059819"], ["updated_at", "2024-03-25 21:10:18.059819"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.060793"], ["updated_at", "2024-03-25 21:10:18.060793"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.072268"], ["updated_at", "2024-03-25 21:10:18.072268"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.4ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:10:18.072927"], ["id", 78]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (11.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.5ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:10:18.110840"], ["updated_at", "2024-03-25 21:10:18.110840"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.4ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:10:18.112291"], ["id", 7]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:10:18 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x0000000116c5d340>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.142208"], ["updated_at", "2024-03-25 21:10:18.142208"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 79], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 9ms (Views: 0.2ms | ActiveRecord: 3.5ms | Allocations: 6426)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:10:18 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000011767fb48>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.151536"], ["updated_at", "2024-03-25 21:10:18.151536"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 80], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 1.1ms | Allocations: 1306)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:10:18 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.155400"], ["updated_at", "2024-03-25 21:10:18.155400"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/81" for 127.0.0.1 at 2024-03-25 15:10:18 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"81", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 81], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (1.1ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 81]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 2ms (Views: 0.0ms | ActiveRecord: 1.3ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 81], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.159730"], ["updated_at", "2024-03-25 21:10:18.159730"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:10:18 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 82], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.162815"], ["updated_at", "2024-03-25 21:10:18.162815"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.163629"], ["updated_at", "2024-03-25 21:10:18.163629"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.164416"], ["updated_at", "2024-03-25 21:10:18.164416"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.165205"], ["updated_at", "2024-03-25 21:10:18.165205"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:10:18 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.2ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.167987"], ["updated_at", "2024-03-25 21:10:18.167987"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/87" for 127.0.0.1 at 2024-03-25 15:10:18 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"87", "creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 87], ["LIMIT", 1]]
+Completed 200 OK in 4ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2042)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.174489"], ["updated_at", "2024-03-25 21:10:18.174489"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/88" for 127.0.0.1 at 2024-03-25 15:10:18 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"88", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 88], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.182155"], ["updated_at", "2024-03-25 21:10:18.182155"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/89" for 127.0.0.1 at 2024-03-25 15:10:18 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"89", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 89], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x0000000116f30fb8>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"89", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 89], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.1ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:10:18.185488"], ["id", 89]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 1ms (Views: 0.0ms | ActiveRecord: 0.4ms | Allocations: 1007)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.189094"], ["updated_at", "2024-03-25 21:10:18.189094"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:10:18 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:10:18.192838"], ["updated_at", "2024-03-25 21:10:18.192838"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.193763"], ["updated_at", "2024-03-25 21:10:18.193763"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:10:18.194725"], ["updated_at", "2024-03-25 21:10:18.194725"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (12.7ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (1.1ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.6ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.9ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.314130"], ["updated_at", "2024-03-25 21:12:29.314130"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.316316"], ["updated_at", "2024-03-25 21:12:29.316316"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.317208"], ["updated_at", "2024-03-25 21:12:29.317208"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.318048"], ["updated_at", "2024-03-25 21:12:29.318048"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.346060"], ["updated_at", "2024-03-25 21:12:29.346060"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.347096"], ["updated_at", "2024-03-25 21:12:29.347096"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.348058"], ["updated_at", "2024-03-25 21:12:29.348058"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.349043"], ["updated_at", "2024-03-25 21:12:29.349043"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.360728"], ["updated_at", "2024-03-25 21:12:29.360728"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.3ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:12:29.361437"], ["id", 101]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (21.3ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.7ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:12:29.409253"], ["updated_at", "2024-03-25 21:12:29.409253"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.4ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:12:29.411577"], ["id", 9]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x0000000107bf8670>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.442963"], ["updated_at", "2024-03-25 21:12:29.442963"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 102], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 9ms (Views: 0.1ms | ActiveRecord: 3.3ms | Allocations: 6426)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010841d350>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.451520"], ["updated_at", "2024-03-25 21:12:29.451520"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 103], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 0.7ms | Allocations: 1306)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.454913"], ["updated_at", "2024-03-25 21:12:29.454913"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/104" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"104", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 104], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (0.9ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 104]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 2ms (Views: 0.1ms | ActiveRecord: 1.0ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 104], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.458596"], ["updated_at", "2024-03-25 21:12:29.458596"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 105], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.461106"], ["updated_at", "2024-03-25 21:12:29.461106"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.461784"], ["updated_at", "2024-03-25 21:12:29.461784"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.462386"], ["updated_at", "2024-03-25 21:12:29.462386"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.463037"], ["updated_at", "2024-03-25 21:12:29.463037"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.465287"], ["updated_at", "2024-03-25 21:12:29.465287"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/110" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"110", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 110], ["LIMIT", 1]]
+Completed 200 OK in 4ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2042)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.471372"], ["updated_at", "2024-03-25 21:12:29.471372"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/111" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"111", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 111], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.479250"], ["updated_at", "2024-03-25 21:12:29.479250"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.0ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.0ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.0ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/112" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"112", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 112], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x0000000107ed0500>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"112", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 112], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:12:29.481841"], ["id", 112]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 1ms (Views: 0.0ms | ActiveRecord: 0.6ms | Allocations: 1007)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.485429"], ["updated_at", "2024-03-25 21:12:29.485429"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:12:29.489218"], ["updated_at", "2024-03-25 21:12:29.489218"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.490159"], ["updated_at", "2024-03-25 21:12:29.490159"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:29.491010"], ["updated_at", "2024-03-25 21:12:29.491010"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/users/10/follows" for 127.0.0.1 at 2024-03-25 15:12:29 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>"10", "creator_id"=>115, "follow"=>{"user_id"=>"10", "creator_id"=>115}}
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mFollow Create (1.3ms)[0m  [1m[32mINSERT INTO "follows" ("user_id", "creator_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["user_id", 10], ["creator_id", 115], ["created_at", "2024-03-25 21:12:29.496850"], ["updated_at", "2024-03-25 21:12:29.496850"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 6ms (Views: 0.0ms | ActiveRecord: 3.9ms | Allocations: 4476)
+  [1m[36mFollow Load (0.1ms)[0m  [1m[34mSELECT "follows".* FROM "follows" ORDER BY "follows"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (1.4ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (0.9ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.7ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.6ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.691414"], ["updated_at", "2024-03-25 21:12:58.691414"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.693270"], ["updated_at", "2024-03-25 21:12:58.693270"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.694193"], ["updated_at", "2024-03-25 21:12:58.694193"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.695113"], ["updated_at", "2024-03-25 21:12:58.695113"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.722456"], ["updated_at", "2024-03-25 21:12:58.722456"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.723372"], ["updated_at", "2024-03-25 21:12:58.723372"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.724201"], ["updated_at", "2024-03-25 21:12:58.724201"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.725032"], ["updated_at", "2024-03-25 21:12:58.725032"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.735237"], ["updated_at", "2024-03-25 21:12:58.735237"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.4ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:12:58.735881"], ["id", 124]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.7ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.6ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:12:58.768324"], ["updated_at", "2024-03-25 21:12:58.768324"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.4ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:12:58.769944"], ["id", 11]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010cdb6908>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.796486"], ["updated_at", "2024-03-25 21:12:58.796486"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 125], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 9ms (Views: 0.2ms | ActiveRecord: 3.6ms | Allocations: 6425)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010cafbf60>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (11.4ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.805811"], ["updated_at", "2024-03-25 21:12:58.805811"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.5ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 126], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 13ms (Views: 0.1ms | ActiveRecord: 12.5ms | Allocations: 1306)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.2ms | Allocations: 394)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.821610"], ["updated_at", "2024-03-25 21:12:58.821610"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/127" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"127", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 127], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (1.3ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 127]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 2ms (Views: 0.1ms | ActiveRecord: 1.5ms | Allocations: 680)
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 127], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.826438"], ["updated_at", "2024-03-25 21:12:58.826438"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 128], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.829683"], ["updated_at", "2024-03-25 21:12:58.829683"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.830585"], ["updated_at", "2024-03-25 21:12:58.830585"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.831511"], ["updated_at", "2024-03-25 21:12:58.831511"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.832403"], ["updated_at", "2024-03-25 21:12:58.832403"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.2ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.835174"], ["updated_at", "2024-03-25 21:12:58.835174"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/133" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"133", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 133], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2042)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.842092"], ["updated_at", "2024-03-25 21:12:58.842092"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/134" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"134", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 134], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.849995"], ["updated_at", "2024-03-25 21:12:58.849995"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/135" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"135", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 135], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x000000010c59dac8>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"135", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 135], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:12:58.853010"], ["id", 135]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 1ms (Views: 0.0ms | ActiveRecord: 0.6ms | Allocations: 1007)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.856454"], ["updated_at", "2024-03-25 21:12:58.856454"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:12:58.859948"], ["updated_at", "2024-03-25 21:12:58.859948"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.860886"], ["updated_at", "2024-03-25 21:12:58.860886"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:12:58.861749"], ["updated_at", "2024-03-25 21:12:58.861749"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/users/12/follows" for 127.0.0.1 at 2024-03-25 15:12:58 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>"12", "creator_id"=>138, "follow"=>{"user_id"=>"12", "creator_id"=>138}}
+Completed 500 Internal Server Error in 7ms (ActiveRecord: 2.7ms | Allocations: 6214)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (1.5ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (0.6ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.7ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.5ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.151664"], ["updated_at", "2024-03-25 21:13:54.151664"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.153437"], ["updated_at", "2024-03-25 21:13:54.153437"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.154312"], ["updated_at", "2024-03-25 21:13:54.154312"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.155150"], ["updated_at", "2024-03-25 21:13:54.155150"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.182625"], ["updated_at", "2024-03-25 21:13:54.182625"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.183712"], ["updated_at", "2024-03-25 21:13:54.183712"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.184560"], ["updated_at", "2024-03-25 21:13:54.184560"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.185369"], ["updated_at", "2024-03-25 21:13:54.185369"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.195829"], ["updated_at", "2024-03-25 21:13:54.195829"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.4ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:13:54.196511"], ["id", 147]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.5ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.4ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:13:54.226911"], ["updated_at", "2024-03-25 21:13:54.226911"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.9ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:13:54.228478"], ["id", 13]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010ca98488>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.256254"], ["updated_at", "2024-03-25 21:13:54.256254"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 148], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 9ms (Views: 0.1ms | ActiveRecord: 3.6ms | Allocations: 6425)
+  [1m[36mCreator Count (11.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010c7dd860>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.277817"], ["updated_at", "2024-03-25 21:13:54.277817"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 149], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 1.3ms | Allocations: 1306)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.282028"], ["updated_at", "2024-03-25 21:13:54.282028"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/150" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"150", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 150], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (1.4ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 150]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 2ms (Views: 0.0ms | ActiveRecord: 1.7ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 150], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.287056"], ["updated_at", "2024-03-25 21:13:54.287056"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 151], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.290237"], ["updated_at", "2024-03-25 21:13:54.290237"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.291245"], ["updated_at", "2024-03-25 21:13:54.291245"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.292181"], ["updated_at", "2024-03-25 21:13:54.292181"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.293117"], ["updated_at", "2024-03-25 21:13:54.293117"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.2ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.295936"], ["updated_at", "2024-03-25 21:13:54.295936"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/156" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"156", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 156], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2042)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.302645"], ["updated_at", "2024-03-25 21:13:54.302645"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/157" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"157", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 157], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.6ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.310272"], ["updated_at", "2024-03-25 21:13:54.310272"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/158" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"158", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 158], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x000000010c27ec48>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"158", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 158], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:13:54.314113"], ["id", 158]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.7ms | Allocations: 1007)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.317652"], ["updated_at", "2024-03-25 21:13:54.317652"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:13:54.321192"], ["updated_at", "2024-03-25 21:13:54.321192"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.322086"], ["updated_at", "2024-03-25 21:13:54.322086"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:13:54.322996"], ["updated_at", "2024-03-25 21:13:54.322996"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/users/14/follows" for 127.0.0.1 at 2024-03-25 15:13:54 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>"14", "creator_id"=>161, "follow"=>{"user_id"=>"14", "creator_id"=>161}}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 14], ["LIMIT", 1]]
+Completed 500 Internal Server Error in 11ms (ActiveRecord: 3.1ms | Allocations: 9692)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (1.5ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (0.7ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.6ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.7ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.014497"], ["updated_at", "2024-03-25 21:14:58.014497"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.016284"], ["updated_at", "2024-03-25 21:14:58.016284"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.017279"], ["updated_at", "2024-03-25 21:14:58.017279"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.018149"], ["updated_at", "2024-03-25 21:14:58.018149"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.4ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.044221"], ["updated_at", "2024-03-25 21:14:58.044221"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.045239"], ["updated_at", "2024-03-25 21:14:58.045239"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.046113"], ["updated_at", "2024-03-25 21:14:58.046113"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.046945"], ["updated_at", "2024-03-25 21:14:58.046945"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.058046"], ["updated_at", "2024-03-25 21:14:58.058046"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.6ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:14:58.058728"], ["id", 170]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.7ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.4ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:14:58.085369"], ["updated_at", "2024-03-25 21:14:58.085369"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.3ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:14:58.086270"], ["id", 15]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010c551100>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.102333"], ["updated_at", "2024-03-25 21:14:58.102333"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 171], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 8ms (Views: 0.1ms | ActiveRecord: 3.0ms | Allocations: 6423)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010c7bc3b8>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.110174"], ["updated_at", "2024-03-25 21:14:58.110174"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 172], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 1ms (Views: 0.1ms | ActiveRecord: 0.7ms | Allocations: 1306)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.113555"], ["updated_at", "2024-03-25 21:14:58.113555"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/173" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"173", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 173], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (0.6ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 173]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 1ms (Views: 0.0ms | ActiveRecord: 0.8ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 173], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.117135"], ["updated_at", "2024-03-25 21:14:58.117135"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.2ms | Allocations: 214)
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 174], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.120278"], ["updated_at", "2024-03-25 21:14:58.120278"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.4ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.121130"], ["updated_at", "2024-03-25 21:14:58.121130"]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.122519"], ["updated_at", "2024-03-25 21:14:58.122519"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.123421"], ["updated_at", "2024-03-25 21:14:58.123421"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.127216"], ["updated_at", "2024-03-25 21:14:58.127216"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/179" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"179", "creator"=>{}}
+  [1m[36mCreator Load (1.4ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 179], ["LIMIT", 1]]
+Completed 200 OK in 6ms (Views: 0.1ms | ActiveRecord: 1.4ms | Allocations: 2016)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.4ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.135761"], ["updated_at", "2024-03-25 21:14:58.135761"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/180" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"180", "creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 180], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.2ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.144135"], ["updated_at", "2024-03-25 21:14:58.144135"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/181" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"181", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 181], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x000000010ca3b5f8>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"181", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 181], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:14:58.147537"], ["id", 181]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 2ms (Views: 0.1ms | ActiveRecord: 0.7ms | Allocations: 1007)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.150806"], ["updated_at", "2024-03-25 21:14:58.150806"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:14:58.154486"], ["updated_at", "2024-03-25 21:14:58.154486"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.155379"], ["updated_at", "2024-03-25 21:14:58.155379"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:14:58.156349"], ["updated_at", "2024-03-25 21:14:58.156349"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/users/16/follows" for 127.0.0.1 at 2024-03-25 15:14:58 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>"16", "creator_id"=>184, "follow"=>{"user_id"=>"16", "creator_id"=>184}}
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 16], ["LIMIT", 1]]
+Completed 500 Internal Server Error in 5ms (ActiveRecord: 0.1ms | Allocations: 4023)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (1.4ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (0.6ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.7ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.5ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.840766"], ["updated_at", "2024-03-25 21:15:39.840766"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.842465"], ["updated_at", "2024-03-25 21:15:39.842465"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.843438"], ["updated_at", "2024-03-25 21:15:39.843438"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.844342"], ["updated_at", "2024-03-25 21:15:39.844342"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.871372"], ["updated_at", "2024-03-25 21:15:39.871372"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.872327"], ["updated_at", "2024-03-25 21:15:39.872327"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.873222"], ["updated_at", "2024-03-25 21:15:39.873222"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.874146"], ["updated_at", "2024-03-25 21:15:39.874146"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.884417"], ["updated_at", "2024-03-25 21:15:39.884417"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.4ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:15:39.885099"], ["id", 193]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.5ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.4ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:15:39.941086"], ["updated_at", "2024-03-25 21:15:39.941086"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.3ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:15:39.941950"], ["id", 17]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:15:39 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010b39f470>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.957661"], ["updated_at", "2024-03-25 21:15:39.957661"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 194], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 9ms (Views: 0.1ms | ActiveRecord: 3.7ms | Allocations: 6423)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:15:39 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010ae74c48>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.966548"], ["updated_at", "2024-03-25 21:15:39.966548"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 195], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 1.1ms | Allocations: 1306)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:15:39 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 2ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (10.8ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (11.2ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.4ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.993765"], ["updated_at", "2024-03-25 21:15:39.993765"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/196" for 127.0.0.1 at 2024-03-25 15:15:39 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"196", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 196], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (1.3ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 196]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 2ms (Views: 0.1ms | ActiveRecord: 1.7ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 196], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:39.998981"], ["updated_at", "2024-03-25 21:15:39.998981"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:15:39 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 197], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:40.002963"], ["updated_at", "2024-03-25 21:15:40.002963"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:40.003959"], ["updated_at", "2024-03-25 21:15:40.003959"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:40.004968"], ["updated_at", "2024-03-25 21:15:40.004968"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:40.005909"], ["updated_at", "2024-03-25 21:15:40.005909"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:15:40 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.2ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:40.008927"], ["updated_at", "2024-03-25 21:15:40.008927"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/202" for 127.0.0.1 at 2024-03-25 15:15:40 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"202", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 202], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2046)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:40.015966"], ["updated_at", "2024-03-25 21:15:40.015966"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/203" for 127.0.0.1 at 2024-03-25 15:15:40 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"203", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 203], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:40.024146"], ["updated_at", "2024-03-25 21:15:40.024146"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/204" for 127.0.0.1 at 2024-03-25 15:15:40 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"204", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 204], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x000000010a5b3d48>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"204", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 204], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:15:40.027070"], ["id", 204]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.6ms | Allocations: 1007)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.0ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:40.030053"], ["updated_at", "2024-03-25 21:15:40.030053"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:15:40 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:15:40.033546"], ["updated_at", "2024-03-25 21:15:40.033546"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:40.034441"], ["updated_at", "2024-03-25 21:15:40.034441"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:40.035278"], ["updated_at", "2024-03-25 21:15:40.035278"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/users/18/follows" for 127.0.0.1 at 2024-03-25 15:15:40 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>"18", "creator_id"=>207, "follow"=>{"user_id"=>"18", "creator_id"=>207}}
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 18], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mFollow Create (0.7ms)[0m  [1m[32mINSERT INTO "follows" ("user_id", "creator_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["user_id", 18], ["creator_id", 207], ["created_at", "2024-03-25 21:15:40.040732"], ["updated_at", "2024-03-25 21:15:40.040732"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 5ms (Views: 0.0ms | ActiveRecord: 0.9ms | Allocations: 4147)
+  [1m[36mFollow Load (0.1ms)[0m  [1m[34mSELECT "follows".* FROM "follows" ORDER BY "follows"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (1.4ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (0.9ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.8ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (1.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.165077"], ["updated_at", "2024-03-25 21:15:44.165077"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.167509"], ["updated_at", "2024-03-25 21:15:44.167509"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.168513"], ["updated_at", "2024-03-25 21:15:44.168513"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.169498"], ["updated_at", "2024-03-25 21:15:44.169498"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.194200"], ["updated_at", "2024-03-25 21:15:44.194200"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.195452"], ["updated_at", "2024-03-25 21:15:44.195452"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.4ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.196527"], ["updated_at", "2024-03-25 21:15:44.196527"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.197470"], ["updated_at", "2024-03-25 21:15:44.197470"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.4ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.208592"], ["updated_at", "2024-03-25 21:15:44.208592"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.5ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:15:44.209702"], ["id", 216]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.6ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.4ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:15:44.261651"], ["updated_at", "2024-03-25 21:15:44.261651"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.4ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:15:44.262567"], ["id", 19]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x00000001085fc450>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.277049"], ["updated_at", "2024-03-25 21:15:44.277049"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 217], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 29ms (Views: 0.1ms | ActiveRecord: 24.7ms | Allocations: 6422)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x00000001080ba500>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.307374"], ["updated_at", "2024-03-25 21:15:44.307374"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 218], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 1.3ms | Allocations: 1306)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.311368"], ["updated_at", "2024-03-25 21:15:44.311368"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/219" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"219", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 219], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (1.2ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 219]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 2ms (Views: 0.1ms | ActiveRecord: 1.5ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 219], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.316175"], ["updated_at", "2024-03-25 21:15:44.316175"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.2ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 220], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.319607"], ["updated_at", "2024-03-25 21:15:44.319607"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.320672"], ["updated_at", "2024-03-25 21:15:44.320672"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.321663"], ["updated_at", "2024-03-25 21:15:44.321663"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.322559"], ["updated_at", "2024-03-25 21:15:44.322559"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.2ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.325288"], ["updated_at", "2024-03-25 21:15:44.325288"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/225" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"225", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 225], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2046)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.332614"], ["updated_at", "2024-03-25 21:15:44.332614"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/226" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"226", "creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 226], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.340040"], ["updated_at", "2024-03-25 21:15:44.340040"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/227" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"227", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 227], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x00000001079f0508>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"227", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 227], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:15:44.343874"], ["id", 227]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 2ms (Views: 0.1ms | ActiveRecord: 0.7ms | Allocations: 1007)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.347106"], ["updated_at", "2024-03-25 21:15:44.347106"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:15:44.351025"], ["updated_at", "2024-03-25 21:15:44.351025"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.351976"], ["updated_at", "2024-03-25 21:15:44.351976"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:15:44.352883"], ["updated_at", "2024-03-25 21:15:44.352883"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/users/20/follows" for 127.0.0.1 at 2024-03-25 15:15:44 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>"20", "creator_id"=>230, "follow"=>{"user_id"=>"20", "creator_id"=>230}}
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 20], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mFollow Create (0.6ms)[0m  [1m[32mINSERT INTO "follows" ("user_id", "creator_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["user_id", 20], ["creator_id", 230], ["created_at", "2024-03-25 21:15:44.357010"], ["updated_at", "2024-03-25 21:15:44.357010"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 4ms (Views: 0.0ms | ActiveRecord: 0.9ms | Allocations: 4147)
+  [1m[36mFollow Load (0.1ms)[0m  [1m[34mSELECT "follows".* FROM "follows" ORDER BY "follows"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (1.6ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (1.0ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.7ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.6ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:24.989697"], ["updated_at", "2024-03-25 21:17:24.989697"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:24.991543"], ["updated_at", "2024-03-25 21:17:24.991543"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:24.992299"], ["updated_at", "2024-03-25 21:17:24.992299"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:24.993040"], ["updated_at", "2024-03-25 21:17:24.993040"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.018708"], ["updated_at", "2024-03-25 21:17:25.018708"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.019609"], ["updated_at", "2024-03-25 21:17:25.019609"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.020371"], ["updated_at", "2024-03-25 21:17:25.020371"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.021050"], ["updated_at", "2024-03-25 21:17:25.021050"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.031801"], ["updated_at", "2024-03-25 21:17:25.031801"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.4ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:17:25.032497"], ["id", 239]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.5ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.6ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:17:25.056225"], ["updated_at", "2024-03-25 21:17:25.056225"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.5ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:17:25.057268"], ["id", 21]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x0000000108d74750>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.073343"], ["updated_at", "2024-03-25 21:17:25.073343"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 240], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 9ms (Views: 0.1ms | ActiveRecord: 4.0ms | Allocations: 6422)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x0000000108f9fa20>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.082031"], ["updated_at", "2024-03-25 21:17:25.082031"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 241], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 0.8ms | Allocations: 1306)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.085595"], ["updated_at", "2024-03-25 21:17:25.085595"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/242" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"242", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 242], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (0.8ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 242]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 1ms (Views: 0.1ms | ActiveRecord: 0.9ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 242], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.089564"], ["updated_at", "2024-03-25 21:17:25.089564"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 243], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.092472"], ["updated_at", "2024-03-25 21:17:25.092472"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.093243"], ["updated_at", "2024-03-25 21:17:25.093243"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.8ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.094829"], ["updated_at", "2024-03-25 21:17:25.094829"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.095645"], ["updated_at", "2024-03-25 21:17:25.095645"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (2.9ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 4ms (Views: 0.1ms | ActiveRecord: 2.9ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.4ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.101377"], ["updated_at", "2024-03-25 21:17:25.101377"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/248" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"248", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 248], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2016)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.108283"], ["updated_at", "2024-03-25 21:17:25.108283"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/249" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"249", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 249], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.4ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.115960"], ["updated_at", "2024-03-25 21:17:25.115960"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/250" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"250", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 250], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x000000010925ece8>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"250", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 250], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:17:25.119140"], ["id", 250]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 1ms (Views: 0.0ms | ActiveRecord: 0.6ms | Allocations: 1007)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.122020"], ["updated_at", "2024-03-25 21:17:25.122020"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:17:25.125587"], ["updated_at", "2024-03-25 21:17:25.125587"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.126467"], ["updated_at", "2024-03-25 21:17:25.126467"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:25.127295"], ["updated_at", "2024-03-25 21:17:25.127295"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/users/22/follows" for 127.0.0.1 at 2024-03-25 15:17:25 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>"22", "creator_id"=>253, "follow"=>{"user_id"=>"22", "creator_id"=>253}}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 22], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mFollow Create (1.1ms)[0m  [1m[32mINSERT INTO "follows" ("user_id", "creator_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["user_id", 22], ["creator_id", 253], ["created_at", "2024-03-25 21:17:25.132622"], ["updated_at", "2024-03-25 21:17:25.132622"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 6ms (Views: 0.0ms | ActiveRecord: 1.4ms | Allocations: 4141)
+  [1m[36mFollow Load (0.1ms)[0m  [1m[34mSELECT "follows".* FROM "follows" ORDER BY "follows"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (1.0ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (0.6ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.9ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.4ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.023789"], ["updated_at", "2024-03-25 21:17:45.023789"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.025243"], ["updated_at", "2024-03-25 21:17:45.025243"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.025981"], ["updated_at", "2024-03-25 21:17:45.025981"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.026778"], ["updated_at", "2024-03-25 21:17:45.026778"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.4ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.054119"], ["updated_at", "2024-03-25 21:17:45.054119"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.055259"], ["updated_at", "2024-03-25 21:17:45.055259"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.056045"], ["updated_at", "2024-03-25 21:17:45.056045"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.056813"], ["updated_at", "2024-03-25 21:17:45.056813"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.3ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.7ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.068658"], ["updated_at", "2024-03-25 21:17:45.068658"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.3ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:17:45.070309"], ["id", 262]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.4ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.3ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:17:45.121990"], ["updated_at", "2024-03-25 21:17:45.121990"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.3ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:17:45.122789"], ["id", 23]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010eb5bff8>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.138425"], ["updated_at", "2024-03-25 21:17:45.138425"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 263], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 8ms (Views: 0.1ms | ActiveRecord: 2.5ms | Allocations: 6423)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010e51a978>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.146255"], ["updated_at", "2024-03-25 21:17:45.146255"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 264], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 0.8ms | Allocations: 1306)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.149874"], ["updated_at", "2024-03-25 21:17:45.149874"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/265" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"265", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 265], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (0.9ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 265]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 2ms (Views: 0.1ms | ActiveRecord: 1.3ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 265], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.154087"], ["updated_at", "2024-03-25 21:17:45.154087"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 266], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.157144"], ["updated_at", "2024-03-25 21:17:45.157144"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.157817"], ["updated_at", "2024-03-25 21:17:45.157817"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.158569"], ["updated_at", "2024-03-25 21:17:45.158569"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.159509"], ["updated_at", "2024-03-25 21:17:45.159509"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.8ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.162576"], ["updated_at", "2024-03-25 21:17:45.162576"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/271" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"271", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 271], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2046)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.169395"], ["updated_at", "2024-03-25 21:17:45.169395"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/272" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"272", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 272], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.177493"], ["updated_at", "2024-03-25 21:17:45.177493"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.0ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.0ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.0ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/273" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"273", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 273], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x000000010dd1d4a0>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"273", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 273], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:17:45.180191"], ["id", 273]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 1ms (Views: 0.0ms | ActiveRecord: 0.6ms | Allocations: 1007)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.183161"], ["updated_at", "2024-03-25 21:17:45.183161"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.1ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:17:45.186539"], ["updated_at", "2024-03-25 21:17:45.186539"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.187234"], ["updated_at", "2024-03-25 21:17:45.187234"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:17:45.188098"], ["updated_at", "2024-03-25 21:17:45.188098"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/users/24/follows" for 127.0.0.1 at 2024-03-25 15:17:45 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>"24", "creator_id"=>276, "follow"=>{"user_id"=>"24", "creator_id"=>276}}
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 24], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mFollow Create (0.8ms)[0m  [1m[32mINSERT INTO "follows" ("user_id", "creator_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["user_id", 24], ["creator_id", 276], ["created_at", "2024-03-25 21:17:45.193273"], ["updated_at", "2024-03-25 21:17:45.193273"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 5ms (Views: 0.0ms | ActiveRecord: 1.0ms | Allocations: 4147)
+  [1m[36mFollow Load (0.1ms)[0m  [1m[34mSELECT "follows".* FROM "follows" ORDER BY "follows"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mActiveRecord::InternalMetadata Load (0.6ms)[0m  [1m[34mSELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1[0m  [[nil, "schema_sha1"]]
+  [1m[36mActiveRecord::SchemaMigration Load (0.5ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+[dotenv] Saved a snapshot of [32mENV[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.293686"], ["updated_at", "2024-03-25 21:18:28.293686"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.295142"], ["updated_at", "2024-03-25 21:18:28.295142"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.295967"], ["updated_at", "2024-03-25 21:18:28.295967"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.296879"], ["updated_at", "2024-03-25 21:18:28.296879"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (10.6ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.335162"], ["updated_at", "2024-03-25 21:18:28.335162"]]
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.3ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.336605"], ["updated_at", "2024-03-25 21:18:28.336605"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.337507"], ["updated_at", "2024-03-25 21:18:28.337507"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.338311"], ["updated_at", "2024-03-25 21:18:28.338311"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Create (0.8ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", nil], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.351140"], ["updated_at", "2024-03-25 21:18:28.351140"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Update (0.3ms)[0m  [1m[33mUPDATE "creators" SET "name" = $1, "updated_at" = $2 WHERE "creators"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:18:28.352349"], ["id", 285]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mCreator Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.6ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", ""], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Create (0.3ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", nil], ["email", nil], ["created_at", "2024-03-25 21:18:28.398512"], ["updated_at", "2024-03-25 21:18:28.398512"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.2ms)[0m  [1m[33mUPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["name", "dummy value"], ["updated_at", "2024-03-25 21:18:28.399362"], ["id", 25]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "dummy value"], ["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "DUMMY VALUE"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mUser Exists? (0.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" IS NULL LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010d5fbff0>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.415026"], ["updated_at", "2024-03-25 21:18:28.415026"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 286], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 8ms (Views: 0.1ms | ActiveRecord: 2.6ms | Allocations: 6423)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: create, request: #<ActionDispatch::Request:0x000000010d0da968>, params: {"name"=>"TestName123abc", "controller"=>"api/v1/creators", "action"=>"create", "creator"=>{"name"=>"TestName123abc"}} }[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "TestName123abc"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.422440"], ["updated_at", "2024-03-25 21:18:28.422440"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "TestName123abc"], ["id", 287], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 2ms (Views: 0.1ms | ActiveRecord: 0.8ms | Allocations: 1306)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started POST "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::CreatorsController#create as HTML
+  Parameters: {"name"=>"TestName123abc", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "TestName123abc"], ["LIMIT", 1]]
+Completed 409 Conflict in 1ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 394)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.426041"], ["updated_at", "2024-03-25 21:18:28.426041"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/288" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"name"=>"TestName123abc", "id"=>"288", "creator"=>{"name"=>"TestName123abc"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 288], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Destroy (11.6ms)[0m  [1m[31mDELETE FROM "creators" WHERE "creators"."id" = $1[0m  [["id", 288]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 204 No Content in 12ms (Views: 0.1ms | ActiveRecord: 11.8ms | Allocations: 680)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 288], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Justin Bieber"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Justin Bieber"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.441073"], ["updated_at", "2024-03-25 21:18:28.441073"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.7ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started DELETE "/api/v1/creators/999999999999999" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::CreatorsController#destroy as HTML
+  Parameters: {"id"=>"999999999999999", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 999999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 289], ["LIMIT", 1]]
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.444814"], ["updated_at", "2024-03-25 21:18:28.444814"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "PewDiePie"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "PewDiePie"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.445703"], ["updated_at", "2024-03-25 21:18:28.445703"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "Markiplier"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "Markiplier"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.446681"], ["updated_at", "2024-03-25 21:18:28.446681"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "jacksepticeye"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "jacksepticeye"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.447518"], ["updated_at", "2024-03-25 21:18:28.447518"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::CreatorsController#index as HTML
+  Parameters: {"creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators"[0m
+Completed 200 OK in 1ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 554)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.450112"], ["updated_at", "2024-03-25 21:18:28.450112"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/294" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"294", "creator"=>{}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 294], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.8ms | ActiveRecord: 0.2ms | Allocations: 2046)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", nil], ["twitch_handle", "8683614"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.457645"], ["updated_at", "2024-03-25 21:18:28.457645"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/creators/295" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::CreatorsController#show as HTML
+  Parameters: {"id"=>"295", "creator"=>{}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 295], ["LIMIT", 1]]
+Completed 200 OK in 5ms (Views: 0.1ms | ActiveRecord: 0.1ms | Allocations: 2288)
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.465616"], ["updated_at", "2024-03-25 21:18:28.465616"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+Started PATCH "/api/v1/creators/296" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"296", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 296], ["LIMIT", 1]]
+[31mUnpermitted parameter: :creator. Context: { controller: Api::V1::CreatorsController, action: update, request: #<ActionDispatch::Request:0x000000010bebb728>, params: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "controller"=>"api/v1/creators", "action"=>"update", "id"=>"296", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.3ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 AND "creators"."id" != $2 LIMIT $3[0m  [["name", "MrBeast"], ["id", 296], ["LIMIT", 1]]
+  [1m[36mCreator Update (0.2ms)[0m  [1m[33mUPDATE "creators" SET "youtube_handle" = $1, "twitch_handle" = $2, "twitter_handle" = $3, "updated_at" = $4 WHERE "creators"."id" = $5[0m  [["youtube_handle", "UCX6OQ3DkcsbYNE6H8uQQuVA"], ["twitch_handle", "mrbeast6000"], ["twitter_handle", "MrBeast"], ["updated_at", "2024-03-25 21:18:28.469131"], ["id", 296]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 200 OK in 1ms (Views: 0.0ms | ActiveRecord: 0.7ms | Allocations: 1007)
+  [1m[36mCreator Count (0.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", nil], ["twitch_handle", nil], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.472074"], ["updated_at", "2024-03-25 21:18:28.472074"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mCreator Count (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+Started PATCH "/api/v1/creators/99999999999999" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::CreatorsController#update as HTML
+  Parameters: {"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast", "id"=>"99999999999999", "creator"=>{"youtube_handle"=>"UCX6OQ3DkcsbYNE6H8uQQuVA", "twitch_handle"=>"mrbeast6000", "twitter_handle"=>"MrBeast"}}
+  [1m[36mCreator Load (0.2ms)[0m  [1m[34mSELECT "creators".* FROM "creators" WHERE "creators"."id" = $1 LIMIT $2[0m  [["id", 99999999999999], ["LIMIT", 1]]
+Completed 404 Not Found in 0ms (Views: 0.0ms | ActiveRecord: 0.1ms | Allocations: 214)
+  [1m[36mCreator Count (0.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "creators"[0m
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.6ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mCreator Load (0.1ms)[0m  [1m[34mSELECT "creators".* FROM "creators" ORDER BY "creators"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.4ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."name" = $1 LIMIT $2[0m  [["name", "Albert Wesker"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.2ms)[0m  [1m[32mINSERT INTO "users" ("name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Albert Wesker"], ["email", "albertwesker@gmail.com"], ["created_at", "2024-03-25 21:18:28.476772"], ["updated_at", "2024-03-25 21:18:28.476772"]]
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "MrBeast"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.1ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "MrBeast"], ["youtube_handle", "pogorulab"], ["twitch_handle", "pogorulab"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.477604"], ["updated_at", "2024-03-25 21:18:28.477604"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mCreator Exists? (0.2ms)[0m  [1m[34mSELECT 1 AS one FROM "creators" WHERE "creators"."name" = $1 LIMIT $2[0m  [["name", "ZFG"], ["LIMIT", 1]]
+  [1m[36mCreator Create (0.2ms)[0m  [1m[32mINSERT INTO "creators" ("name", "youtube_handle", "twitch_handle", "twitter_handle", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["name", "ZFG"], ["youtube_handle", "donkus"], ["twitch_handle", "blonkus"], ["twitter_handle", nil], ["created_at", "2024-03-25 21:18:28.478451"], ["updated_at", "2024-03-25 21:18:28.478451"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/users/26/follows" for 127.0.0.1 at 2024-03-25 15:18:28 -0600
+Processing by Api::V1::FollowsController#create as JSON
+  Parameters: {"user_id"=>"26", "creator_id"=>299, "follow"=>{"user_id"=>"26", "creator_id"=>299}}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 26], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mFollow Create (0.7ms)[0m  [1m[32mINSERT INTO "follows" ("user_id", "creator_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["user_id", 26], ["creator_id", 299], ["created_at", "2024-03-25 21:18:28.483886"], ["updated_at", "2024-03-25 21:18:28.483886"]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Completed 201 Created in 5ms (Views: 0.0ms | ActiveRecord: 1.0ms | Allocations: 4151)
+  [1m[36mFollow Load (0.1ms)[0m  [1m[34mSELECT "follows".* FROM "follows" ORDER BY "follows"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Follow do
+    it { should validate_presence_of(:creator_id) }
+    it { should belong_to(:user) }
+end

--- a/spec/requests/follow_request_spec.rb
+++ b/spec/requests/follow_request_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Api::V1::follow", type: :request do
                     "Accept": "application/json"
                 }
 
-                post api_v1_follows_path, headers: headers, params: JSON.generate(follow_params)
+                post "/api/v1/users/#{@user1.id}/follows", headers: headers, params: JSON.generate(follow_params)
 
                 new_follow = Follow.last
                 result = JSON.parse(response.body, symbolize_names: true)


### PR DESCRIPTION
## Description
Make Follows belong to Users instead of being a in-between table

## What type of PR is this? (check all applicable)
- [ ] 💡💫 Feature
- [ ] 🐞🐛 Fix
- [x] 🪸🎭 Refactor
- [ ] 💅🎨 Style
- [ ] 📄💾 Documentation

## Reviewers
Dylan, Isaac, Quin

## Changes
List the changes introduced by this pull request.
- Follows belongs to Users

## How Has This Been Tested?
Describe testing implemented and what all it covers.
- Follow Model spec
- Follow Request Spec

## Related Issues
Indicate any related issues that this pull request addresses or resolves.
- We can now use User.follows to get the Follows data instead of running through every single Follow

## Checklist
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] Documentation has been updated (if applicable).
- [x] I have added/updated unit tests (if applicable).
- [x] I have squashed/organized my commits.

## Additional Notes
Add any additional information that might be relevant for reviewers.

### Thanks, GO TEAM! 👏