### PR TITLE
Feat/follow delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 # Ignore CircleCI temp files
 /tmp
 /log/test.log
+ 

--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -10,6 +10,13 @@ class Api::V1::FollowsController < ApplicationController
             render json: follow.errors, status: :bad_request
         end
     end
+
+    def destroy
+        follow = find_follow_by_id(params[:id])
+
+        follow.destroy
+        head :no_content # sends a 204 no content response
+    end
 end
 
 private

--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -1,7 +1,8 @@
 class Api::V1::FollowsController < ApplicationController
     def create
-        user = User.find_by(id: params[:user_id])
-        follow = user.follows.new(creator_id: params[:creator_id])
+        user = find_user_by_id(params[:user_id])
+        creator = find_creator_by_id(params[:creator_id])
+        follow = user.follows.new(creator_id: creator.id)
 
         if follow.save
             render json: { success: "Follow added successfully" }, status: :created

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,4 +22,12 @@ class ApplicationController < ActionController::API
             raise ActiveRecord::RecordNotFound
         end
     end
+
+    def find_follow_by_id(id)
+        if follow = Follow.find(id)
+            follow
+        else
+            raise ActiveRecord::RecordNotFound
+        end
+    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :creators, only: [:show, :index, :create, :update, :destroy]
       resources :users, only: [:create] do
-        resources :follows, only: [:create]
+        resources :follows, only: [:create, :destroy]
       end
     end
   end

--- a/spec/requests/follow/create_spec.rb
+++ b/spec/requests/follow/create_spec.rb
@@ -1,0 +1,103 @@
+RSpec.describe "Api::V1::follow", type: :request do
+    describe "Follow Create" do
+        before :each do
+            @user1 = User.create!(
+                name: "Albert Wesker",
+                email: "albertwesker@gmail.com"
+                )
+
+            @creator1 = Creator.create!(
+                name: "MrBeast",
+                youtube_handle: "pogorulab",
+                twitch_handle: "pogorulab"
+                )
+
+            @creator2 = Creator.create!(
+                name: "ZFG",
+                youtube_handle: "donkus",
+                twitch_handle: "blonkus"
+                )
+        end
+
+        describe "happy path" do
+            it "creates a follow" do
+                follow_params = {
+                    user_id: @user1.id,
+                    creator_id: @creator2.id
+                }
+                headers = { 
+                    "Content-Type": "application/json",
+                    "Accept": "application/json"
+                }
+
+                post "/api/v1/users/#{@user1.id}/follows", headers: headers, params: JSON.generate(follow_params)
+
+                new_follow = Follow.last
+                result = JSON.parse(response.body, symbolize_names: true)
+
+                expect(response).to be_successful
+                expect(response.status).to eq(201)
+
+                expect(new_follow.user_id).to eq(follow_params[:user_id])
+                expect(new_follow.creator_id).to eq(follow_params[:creator_id])
+
+                # JSON formatting according to front end spec
+                expect(result).to be_a(Hash)
+
+                expect(result[:success]).to eq("Follow added successfully")
+            end
+        end
+
+        describe "sad path" do
+            it "errors out when user ID does not match existing users" do
+                follow_params = {
+                    user_id: 444,
+                    creator_id: @creator2.id
+                }
+                headers = { 
+                    "Content-Type": "application/json",
+                    "Accept": "application/json"
+                }
+
+                post "/api/v1/users/444/follows", headers: headers, params: JSON.generate(follow_params)
+
+                result = JSON.parse(response.body, symbolize_names: true)
+
+                require 'pry'; binding.pry
+
+                expect(response).to_not be_successful
+                expect(response.status).to eq(401)
+
+                # JSON formatting according to front end spec
+                expect(result).to be_a(Hash)
+
+                expect(result[:error]).to eq("Sorry, your credentials are bad!")
+            end
+
+            it "errors out when creator ID does not match existing creators" do
+                follow_params = {
+                    user_id: @user1.id,
+                    creator_id: 444
+                }
+                headers = { 
+                    "Content-Type": "application/json",
+                    "Accept": "application/json"
+                }
+
+                post "/api/v1/users/#{@user1.id}/follows", headers: headers, params: JSON.generate(follow_params)
+
+                result = JSON.parse(response.body, symbolize_names: true)
+
+                require 'pry'; binding.pry
+
+                expect(response).to_not be_successful
+                expect(response.status).to eq(401)
+
+                # JSON formatting according to front end spec
+                expect(result).to be_a(Hash)
+
+                expect(result[:error]).to eq("Sorry, your credentials are bad!")
+            end
+        end
+    end
+end

--- a/spec/requests/follow/create_spec.rb
+++ b/spec/requests/follow/create_spec.rb
@@ -63,8 +63,6 @@ RSpec.describe "Api::V1::follow", type: :request do
 
                 result = JSON.parse(response.body, symbolize_names: true)
 
-                require 'pry'; binding.pry
-
                 expect(response).to_not be_successful
                 expect(response.status).to eq(401)
 
@@ -87,8 +85,6 @@ RSpec.describe "Api::V1::follow", type: :request do
                 post "/api/v1/users/#{@user1.id}/follows", headers: headers, params: JSON.generate(follow_params)
 
                 result = JSON.parse(response.body, symbolize_names: true)
-
-                require 'pry'; binding.pry
 
                 expect(response).to_not be_successful
                 expect(response.status).to eq(401)

--- a/spec/requests/follow/delete_spec.rb
+++ b/spec/requests/follow/delete_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Api::V1::follow", type: :request do
-    describe "Follow Create" do
+    describe "Follow Delete" do
         before :each do
             @user1 = User.create!(
                 name: "Albert Wesker",

--- a/spec/requests/follow/delete_spec.rb
+++ b/spec/requests/follow/delete_spec.rb
@@ -17,35 +17,29 @@ RSpec.describe "Api::V1::follow", type: :request do
                 youtube_handle: "donkus",
                 twitch_handle: "blonkus"
                 )
+
+            @follow1 = @user1.follows.create!(
+                creator_id: @creator2.id
+            )
         end
 
         describe "happy path" do
-            it "creates a follow" do
-                follow_params = {
-                    user_id: @user1.id,
-                    creator_id: @creator2.id
-                }
-                headers = { 
-                    "Content-Type": "application/json",
-                    "Accept": "application/json"
-                }
+            it "deletes a follow" do
 
-                post "/api/v1/users/#{@user1.id}/follows", headers: headers, params: JSON.generate(follow_params)
+                delete api_v1_user_follow_path(@user1.id, @follow1.id)
 
-                new_follow = Follow.last
-                result = JSON.parse(response.body, symbolize_names: true)
-
-                expect(response).to be_successful
-                expect(response.status).to eq(201)
-
-                expect(new_follow.user_id).to eq(follow_params[:user_id])
-                expect(new_follow.creator_id).to eq(follow_params[:creator_id])
-
-                # JSON formatting according to front end spec
-                expect(result).to be_a(Hash)
-
-                expect(result[:success]).to eq("Follow added successfully")
+                expect(response.status).to eq(204)
+                expect(Follow.count).to eq(0)
+                expect{Follow.find(@follow1.id)}.to raise_error(ActiveRecord::RecordNotFound)
             end
+
+            describe "sad path" do
+                it 'returns a 401 if the follow does not exist' do
+                  delete api_v1_user_follow_path(@user1.id, 444) 
+            
+                  expect(response.status).to eq(401)
+                end
+              end
         end
     end
 end


### PR DESCRIPTION
## Description
Adds follow delete functionality and tests

## What type of PR is this? (check all applicable)
- [x] 💡💫 Feature
- [ ] 🐞🐛 Fix
- [ ] 🪸🎭 Refactor
- [ ] 💅🎨 Style
- [ ] 📄💾 Documentation

## Reviewers
Dylan, Isaac, Quin

## Changes
List the changes introduced by this pull request.
- Follows can now be deleted by hitting the endpoint `user/:user_id/follows/:follow_id`

## How Has This Been Tested?
Describe testing implemented and what all it covers.
- Happy path testing for 204 response code
- Sad path testing for 401 response code when follow_id mismatches

## Checklist
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] Documentation has been updated (if applicable).
- [x] I have added/updated unit tests (if applicable).
- [x] I have squashed/organized my commits.

## Additional Notes
Add any additional information that might be relevant for reviewers.

### Thanks, GO TEAM! 👏