### PR TITLE
Fix twitch get_channel service to accept handle argument

### DIFF
--- a/app/services/twitch_service.rb
+++ b/app/services/twitch_service.rb
@@ -15,6 +15,6 @@ class TwitchService
     def get_channel(handle, query)
         max_results = 5
         query = '' # delete this line if we are going to add search functionality
-        get_url("https://api.twitch.tv/helix/videos?user_id=8683614?&first=#{max_results}")
+        get_url("https://api.twitch.tv/helix/videos?user_id=#{handle}&first=#{max_results}")
     end
 end

--- a/spec/requests/creator/show_spec.rb
+++ b/spec/requests/creator/show_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Api::V1::creators", type: :request do
             @zfg = Creator.create(  name: "ZFG",
                                     twitch_handle: "8683614")
                                    
-             stub_request(:get, "https://api.twitch.tv/helix/videos?first=5&user_id=8683614?").
+             stub_request(:get, "https://api.twitch.tv/helix/videos?first=5&user_id=8683614").
              with(
                  headers: {
                  'Accept'=>'*/*',


### PR DESCRIPTION
## Description

## What type of PR is this? (check all applicable)
- [ ] 💡💫 Feature
- [x] 🐞🐛 Fix
- [ ] 🪸🎭 Refactor
- [ ] 💅🎨 Style
- [ ] 📄💾 Documentation

## Reviewers
Dylan, Isaac, Quin

## Changes
List the changes introduced by this pull request.
- The service for twitch videos was formerly hardcoded by mistake. This reintroduces dynamic ID calls for the service.

## How Has This Been Tested?
Describe testing implemented and what all it covers.
- WebMock

## Checklist
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] Documentation has been updated (if applicable).
- [x] I have added/updated unit tests (if applicable).
- [x] I have squashed/organized my commits.

## Additional Notes
Add any additional information that might be relevant for reviewers.

### Thanks, GO TEAM! 👏