### PR TITLE
Follows now finds follows by Creator ID instead of Follow ID

### DIFF
--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -10,19 +10,25 @@ class Api::V1::FollowsController < ApplicationController
     end
 
     def destroy
-        follow = Follow.find_by(id: params[:id])
-        if follow != nil
-            if follow.user_id == params[:user_id].to_i
-                if follow.destroy
-                    render json: FollowSerializer.new(follow), status: :no_content
+        user = User.find_by(id: params[:user_id])
+        if user != nil
+            creator = Creator.find_by(id: params[:id])
+            if creator != nil
+                follow = user.follows.find_by(creator_id: creator.id)
+                if follow != nil
+                    if follow.destroy
+                        render json: FollowSerializer.new(follow), status: :no_content
+                    else
+                        render json: ErrorSerializer.new(ErrorMessage.new("Follow delete failed.", 500)), status: :internal_server_error
+                    end
                 else
-                    render json: ErrorSerializer.new(ErrorMessage.new("Follow delete failed.", 500)), status: :internal_server_error
+                    render json: ErrorSerializer.new(ErrorMessage.new("Follow not found.", 404)), status: :not_found
                 end
             else
-                render json: ErrorSerializer.new(ErrorMessage.new("user.id does not equal follow.user_id.", 404)), status: :not_found
+                render json: ErrorSerializer.new(ErrorMessage.new("Creator not found.", 404)), status: :not_found
             end
         else
-            render json: ErrorSerializer.new(ErrorMessage.new("Follow not found.", 404)), status: :not_found
+            render json: ErrorSerializer.new(ErrorMessage.new("User not found.", 404)), status: :not_found
         end
     end
 end

--- a/spec/requests/follow/delete_spec.rb
+++ b/spec/requests/follow/delete_spec.rb
@@ -10,25 +10,25 @@ RSpec.describe 'Follow Delete' do
     it 'DELETE Follow [HAPPY]' do
         expect(Follow.find_by(id: @follow.id)).to_not eq(nil)
 
-        delete "/api/v1/users/#{@user.id}/follows/#{@follow.id}", headers: {"CONTENT_TYPE" => "application/json"}
+        delete "/api/v1/users/#{@user.id}/follows/#{@creator.id}", headers: {"CONTENT_TYPE" => "application/json"}
         expect(response).to have_http_status(204)
 
         expect(Follow.find_by(id: @follow.id)).to eq(nil)
     end
 
-    it 'DELETE Follow - [SAD]-bad follow id' do
+    it 'DELETE Follow - [SAD]-bad creator id' do
         delete "/api/v1/users/#{@user.id}/follows/#{999999999999999}", headers: {"CONTENT_TYPE" => "application/json"}
         expect(response).to have_http_status(404)
         json_response = JSON.parse(response.body)
 
-        expect(json_response['error_object']['message']).to eq('Follow not found.')
+        expect(json_response['error_object']['message']).to eq('Creator not found.')
     end
 
     it 'DELETE Follow - [SAD]-bad user id' do
-        delete "/api/v1/users/#{999999999999999}/follows/#{@follow.id}", headers: {"CONTENT_TYPE" => "application/json"}
+        delete "/api/v1/users/#{999999999999999}/follows/#{@creator.id}", headers: {"CONTENT_TYPE" => "application/json"}
         expect(response).to have_http_status(404)
         json_response = JSON.parse(response.body)
 
-        expect(json_response['error_object']['message']).to eq('user.id does not equal follow.user_id.')
+        expect(json_response['error_object']['message']).to eq('User not found.')
     end
 end


### PR DESCRIPTION
## Description
Follows now finds follows by Creator ID instead of Follow ID 

## What type of PR is this? (check all applicable)
- [ ] 💡💫 Feature
- [x] 🐞🐛 Fix
- [x] 🪸🎭 Refactor
- [ ] 💅🎨 Style
- [ ] 📄💾 Documentation

## Reviewers
Dylan, Isaac

## Changes
List the changes introduced by this pull request.
- Follows now finds follows by Creator ID instead of Follow ID

## How Has This Been Tested?
Describe testing implemented and what all it covers.
- DELETE Follow [HAPPY]
- DELETE Follow - [SAD]-bad creator id
- DELETE Follow - [SAD]-bad user id

## Related Issues
I think the reason why frontend cant delete is because they are inputting the creator id instead of the follow id.

## Checklist
- [x] I have read the contribution guidelines.
- [x]  I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] Documentation has been updated (if applicable).
- [x] I have added/updated unit tests (if applicable).
- [x] I have squashed/organized my commits.

## Additional Notes
Add any additional information that might be relevant for reviewers.

### Thanks, GO TEAM! 👏